### PR TITLE
feat: integrate Allure reporting for test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 .env
 *.log
+allure-results/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -sv
+addopts = -sv --alluredir=allure-results
 log_cli = true
 log_cli_level = DEBUG

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 pytest
 pydantic
+allure-pytest

--- a/tests/test_login_api.py
+++ b/tests/test_login_api.py
@@ -1,13 +1,28 @@
 from models import LoginResponse
+import allure
 
 
+@allure.feature("Login")
+@allure.story("Successful login")
+@allure.title("Successful login with valid email and password")
+@allure.description("Тест проверяет успешный логин с валидными email и password.")
 def test_successful_login(client):
-    response = client.login(email="eve.holt@reqres.in", password="cityslicka")
-    assert isinstance(response, LoginResponse)
-    assert response.token
+    with allure.step("Выполняем запрос логина с валидными данными"):
+        response = client.login(email="eve.holt@reqres.in", password="cityslicka")
+    with allure.step("Проверяем, что ответ является экземпляром LoginResponse"):
+        assert isinstance(response, LoginResponse)
+    with allure.step("Проверяем, что в ответе есть токен"):
+        assert response.token
 
 
+@allure.feature("Login")
+@allure.story("Failed login")
+@allure.title("Unsuccessful login with valid email and empty password")
+@allure.description("Тест проверяет ошибку при попытке логина без пароля.")
 def test_login_missing_password(client):
-    response = client.login(email="eve.holt@reqres.in", password="", raise_on_error=False)
-    assert response.status_code == 400, f"При попытке логина без пароля - вернулся {response.status_code} статус-код"
-    assert response.json()["error"] == "Missing password"
+    with allure.step("Выполняем запрос логина без пароля"):
+        response = client.login(email="eve.holt@reqres.in", password="", raise_on_error=False)
+    with allure.step("Проверяем, что статус код 400"):
+        assert response.status_code == 400, f"При попытке логина без пароля - вернулся {response.status_code} статус-код"
+    with allure.step("Проверяем, что сообщение об ошибке 'Missing password' присутствует в ответе"):
+        assert response.json()["error"] == "Missing password"


### PR DESCRIPTION
- Installed allure-pytest and added to requirements.txt
- Configured pytest.ini to save results to allure-results directory
- Added Allure annotations
- Updated existing login tests with Allure reporting structure