### PR TITLE
feat: add user creation test with Faker data and adjust logging level

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -1,6 +1,6 @@
 import requests
 from api.base_client import BaseClient
-from models import LoginResponse
+from models import LoginResponse, CreateResponse
 
 
 class ReqresClient(BaseClient):
@@ -18,3 +18,11 @@ class ReqresClient(BaseClient):
 
     def get_users(self, page: int = 1, raise_on_error: bool = True) -> requests.Response:
         return self.get(endpoint="/users", params={"page": page}, raise_on_error=raise_on_error)
+
+    def create_user(self, name: str, job: str, raise_on_error: bool = True) -> CreateResponse | requests.Response:
+        data = {"name": name, "job": job}
+        response = self.post(endpoint="/users", json=data, raise_on_error=raise_on_error)
+
+        if raise_on_error:
+            return CreateResponse(**response.json())
+        return response

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from faker import Faker
 from utils.logger import setup_logging
 from api.client import ReqresClient
 
@@ -11,3 +12,13 @@ def configure_logging():
 @pytest.fixture(scope="session")
 def client():
     return ReqresClient()
+
+
+@pytest.fixture(scope="session")
+def faker():
+    return Faker("ru_RU")
+
+
+@pytest.fixture(scope="function")
+def user_data(faker):
+    return {"name": faker.name(), "job": faker.job()}

--- a/models.py
+++ b/models.py
@@ -1,5 +1,14 @@
+import datetime
+
 from pydantic import BaseModel
 
 
 class LoginResponse(BaseModel):
     token: str
+
+
+class CreateResponse(BaseModel):
+    name: str
+    job: str
+    id: str
+    createdAt: datetime.datetime

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 addopts = -sv --alluredir=allure-results
 log_cli = true
-log_cli_level = DEBUG
+log_cli_level = INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pytest
 pydantic
 allure-pytest
+faker

--- a/tests/test_create_user_api.py
+++ b/tests/test_create_user_api.py
@@ -1,0 +1,21 @@
+from models import CreateResponse
+import allure
+
+
+@allure.feature("Creating user")
+@allure.story("User creation with valid data")
+@allure.title("User is created successfully with valid name and job")
+@allure.description("Тест проверяет успешное создание пользователя с валидными name и job.")
+def test_successful_create_user(client, user_data):
+    name = user_data["name"]
+    job = user_data["job"]
+    with allure.step("Выполняем запрос создания пользователя с валидными данными"):
+        response = client.create_user(name=name, job=job)
+    with allure.step("Проверяем, что ответ является экземпляром CreateResponse"):
+        assert isinstance(response, CreateResponse)
+    with allure.step("Проверяем, что в ответе возвращаются заданные name и job"):
+        assert response.name == name, f"Возвращаемое имя: {response.name} не совпадает с пришедшим на вход: {name}"
+        assert response.job == job, f"Возвращаемая работа: {response.job} не совпадает с пришедшей на вход: {job}"
+    with allure.step("Проверяем, что в ответе есть id и createdAt"):
+        assert response.id, "В ответе не возвращается id"
+        assert response.createdAt, "В ответе не возвращается createdAt"


### PR DESCRIPTION
- added `create_user` method to ApiClient
- introduced `CreateResponse` Pydantic model for user creation response
- implemented `test_successful_create_user` using generated test data
- added `test_data_for_creating_user` fixture with Faker (ru_RU locale)
- integrated Allure annotations and steps for the new test
- changed log level from DEBUG to INFO in pytest.ini